### PR TITLE
feat: 레이어 컨벤션 설정 및 공용 코드 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,9 @@ dependencies {
     // Redis
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
 
+    // Tsid
+    implementation("com.github.f4b6a3:tsid-creator:$tsidCreatorVersion")
+
     // JUnit
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+### Tsid ###
+tsidCreatorVersion=5.2.6

--- a/src/main/java/com/teamflow/forestory_be/support/common/domain/AggregateRoot.java
+++ b/src/main/java/com/teamflow/forestory_be/support/common/domain/AggregateRoot.java
@@ -1,0 +1,11 @@
+package com.teamflow.forestory_be.support.common.domain;
+
+/**
+ * AggregateRoot 는 해당 애그리게이트의 유일한 진입점으로, 일관성과 트랜잭션 경계를 보장합니다.
+ * <p>
+ * 하나의 애그리게이트에는 반드시 하나의 루트만 존재해야 하며, 도메인 엔티티는 해당 클래스를 상속받아야 합니다.
+ *
+ * @author junseoparkk
+ */
+public abstract class AggregateRoot extends DomainEntity {
+}

--- a/src/main/java/com/teamflow/forestory_be/support/common/domain/BaseTimeEntity.java
+++ b/src/main/java/com/teamflow/forestory_be/support/common/domain/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.teamflow.forestory_be.support.common.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/teamflow/forestory_be/support/common/domain/DomainEntity.java
+++ b/src/main/java/com/teamflow/forestory_be/support/common/domain/DomainEntity.java
@@ -1,0 +1,35 @@
+package com.teamflow.forestory_be.support.common.domain;
+
+import com.teamflow.forestory_be.support.common.util.TsidGenerator;
+import java.util.Objects;
+
+public abstract class DomainEntity {
+
+    public abstract Long id();
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        DomainEntity entity = (DomainEntity) other;
+        return Objects.equals(id(), entity.id());
+    }
+
+    @Override
+    public int hashCode() {
+        return id().hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "(id=" + id() + ")";
+    }
+
+    public static Long generateId() {
+        return TsidGenerator.generate();
+    }
+}

--- a/src/main/java/com/teamflow/forestory_be/support/common/exception/CustomException.java
+++ b/src/main/java/com/teamflow/forestory_be/support/common/exception/CustomException.java
@@ -1,0 +1,22 @@
+package com.teamflow.forestory_be.support.common.exception;
+
+/**
+ * 모든 도메인 예외의 최상위 추상 클래스입니다. 공통적으로 사용하는 예외 코드(code)와 메시지(message)를 포함합니다.
+ * <p>
+ * 각 도메인별 BaseException은 해당 클래스를 상속받아 구현합니다.
+ *
+ * @author junseoparkk
+ */
+public abstract class CustomException extends RuntimeException {
+
+    private final String code;
+
+    protected CustomException(String code, String message) {
+        super(message);
+        this.code = code;
+    }
+
+    public String getCode() {
+        return code;
+    }
+}

--- a/src/main/java/com/teamflow/forestory_be/support/common/util/TsidGenerator.java
+++ b/src/main/java/com/teamflow/forestory_be/support/common/util/TsidGenerator.java
@@ -1,0 +1,22 @@
+package com.teamflow.forestory_be.support.common.util;
+
+import com.github.f4b6a3.tsid.TsidFactory;
+
+public final class TsidGenerator {
+
+    private static TsidFactory factory;
+
+    private TsidGenerator() {
+    }
+
+    public static void initialize(TsidFactory tsidFactory) {
+        factory = tsidFactory;
+    }
+
+    public static Long generate() {
+        if (factory == null) {
+            throw new IllegalStateException("TsidGenerator does not exists");
+        }
+        return factory.create().toLong();
+    }
+}

--- a/src/main/java/com/teamflow/forestory_be/support/config/IdGeneratorConfig.java
+++ b/src/main/java/com/teamflow/forestory_be/support/config/IdGeneratorConfig.java
@@ -1,0 +1,23 @@
+package com.teamflow.forestory_be.support.config;
+
+import com.github.f4b6a3.tsid.TsidFactory;
+import com.teamflow.forestory_be.support.common.util.TsidGenerator;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class IdGeneratorConfig {
+
+    @Value("${server.node:0}")
+    private int node;
+
+    @Bean
+    public TsidFactory tsidFactory() {
+        TsidFactory factory = TsidFactory.builder()
+            .withNode(node)
+            .build();
+        TsidGenerator.initialize(factory);
+        return factory;
+    }
+}

--- a/src/main/java/com/teamflow/forestory_be/support/config/JpaConfig.java
+++ b/src/main/java/com/teamflow/forestory_be/support/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.teamflow.forestory_be.support.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}


### PR DESCRIPTION
## 📝 개요

- 레이어 컨벤션 설정 및 모든 도메인에서 공통적으로 사용하는 클래스를 추가합니다.

## 🔥 변경 사항

- 의존성 버전 관리를 위한 `settings.gradle`을 추가합니다.
- 레이어 컨벤션을 맞추기 위한 `support` 패키지를 추가합니다.
    - Id 생성을 위한 `Tsid` 관련 설정 및 클래스를 추가합니다.
    - 도메인 레이어에서 사용하는 `AggregateRoot`, `DomainEntity`를 추가합니다.
    - 커스텀 예외를 위한 `CustomException`을 추가합니다.

## 🔗 관련 이슈

 <!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략) -->

- closed #4 

## ℹ️ 참고 사항
 
- `AggregateRoot` 도입 등 아직 정하지 못한 컨벤션에 대해 이야기를 나눠보면 좋을 것 같습니다!
- 도메인 엔티티 생성과 관련된 고민이 있는데, 추후 디스커션에 해당 주제를 올리겠습니다.
- 궁금한 점이 있다면 언제든 연락주세요😀