### PR TITLE
feat: 사용자 기능 기본 구조 설정 및 생성, 수정, 조회 추가

### DIFF
--- a/src/main/java/com/teamflow/forestory_be/user/application/dto/CreateUserCommand.java
+++ b/src/main/java/com/teamflow/forestory_be/user/application/dto/CreateUserCommand.java
@@ -2,7 +2,6 @@ package com.teamflow.forestory_be.user.application.dto;
 
 public record CreateUserCommand(
     String name,
-    String description,
     String profileImageUrl
 ) {
 }

--- a/src/main/java/com/teamflow/forestory_be/user/application/dto/CreateUserCommand.java
+++ b/src/main/java/com/teamflow/forestory_be/user/application/dto/CreateUserCommand.java
@@ -1,0 +1,8 @@
+package com.teamflow.forestory_be.user.application.dto;
+
+public record CreateUserCommand(
+    String name,
+    String description,
+    String profileImageUrl
+) {
+}

--- a/src/main/java/com/teamflow/forestory_be/user/application/dto/ReadUserQuery.java
+++ b/src/main/java/com/teamflow/forestory_be/user/application/dto/ReadUserQuery.java
@@ -1,0 +1,6 @@
+package com.teamflow.forestory_be.user.application.dto;
+
+public record ReadUserQuery(
+    Long userId
+) {
+}

--- a/src/main/java/com/teamflow/forestory_be/user/application/dto/UpdateUserCommand.java
+++ b/src/main/java/com/teamflow/forestory_be/user/application/dto/UpdateUserCommand.java
@@ -3,7 +3,6 @@ package com.teamflow.forestory_be.user.application.dto;
 public record UpdateUserCommand(
     Long userId,
     String name,
-    String description,
     String profileImageUrl
 ) {
 }

--- a/src/main/java/com/teamflow/forestory_be/user/application/dto/UpdateUserCommand.java
+++ b/src/main/java/com/teamflow/forestory_be/user/application/dto/UpdateUserCommand.java
@@ -1,0 +1,9 @@
+package com.teamflow.forestory_be.user.application.dto;
+
+public record UpdateUserCommand(
+    Long userId,
+    String name,
+    String description,
+    String profileImageUrl
+) {
+}

--- a/src/main/java/com/teamflow/forestory_be/user/application/service/UserService.java
+++ b/src/main/java/com/teamflow/forestory_be/user/application/service/UserService.java
@@ -1,0 +1,43 @@
+package com.teamflow.forestory_be.user.application.service;
+
+import com.teamflow.forestory_be.user.application.dto.CreateUserCommand;
+import com.teamflow.forestory_be.user.application.dto.ReadUserQuery;
+import com.teamflow.forestory_be.user.application.dto.UpdateUserCommand;
+import com.teamflow.forestory_be.user.domain.entity.User;
+import com.teamflow.forestory_be.user.domain.repository.UserRepositoryPort;
+import com.teamflow.forestory_be.user.domain.vo.Name;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepositoryPort userRepositoryPort;
+
+    @Transactional
+    public void create(CreateUserCommand command) {
+        Name name = new Name(command.name());
+        User user = User.create(
+            name,
+            command.profileImageUrl()
+        );
+        userRepositoryPort.save(user);
+    }
+
+    @Transactional
+    public void update(UpdateUserCommand command) {
+        User user = userRepositoryPort.getById(command.userId());
+        Name name = new Name(command.name());
+        User updatedUser = user.update(
+            name,
+            command.profileImageUrl()
+        );
+        userRepositoryPort.save(updatedUser);
+    }
+
+    public User getUserById(ReadUserQuery query) {
+        return userRepositoryPort.getById(query.userId());
+    }
+}

--- a/src/main/java/com/teamflow/forestory_be/user/domain/entity/User.java
+++ b/src/main/java/com/teamflow/forestory_be/user/domain/entity/User.java
@@ -1,0 +1,49 @@
+package com.teamflow.forestory_be.user.domain.entity;
+
+import com.teamflow.forestory_be.support.common.util.TsidGenerator;
+import com.teamflow.forestory_be.user.domain.vo.Name;
+import com.teamflow.forestory_be.user.domain.vo.UserStatus;
+import java.util.Objects;
+import lombok.Getter;
+
+@Getter
+public class User {
+
+    private final Long id;
+    private final Name name;
+    private final String profileImageUrl;
+    private final UserStatus status;
+
+    private User(Long id, Name name, String profileImageUrl, UserStatus status) {
+        this.id = Objects.requireNonNull(id);
+        this.name = Objects.requireNonNull(name);
+        this.profileImageUrl = profileImageUrl;
+        this.status = Objects.requireNonNull(status);
+    }
+
+    public User update(Name name, String profileImageUrl) {
+        return new User(
+            this.id,
+            updateIfDifferent(name, this.name),
+            updateIfDifferent(profileImageUrl, this.profileImageUrl),
+            this.status
+        );
+    }
+
+    public static User create(Name name, String profileImageUrl) {
+        Long id = TsidGenerator.generate();
+        return new User(id, name, profileImageUrl, UserStatus.ONBOARDING);
+    }
+
+    public static User reconstruct(Long id, Name name, String profileImageUrl, UserStatus status) {
+        return new User(id, name, profileImageUrl, status);
+    }
+
+    // TODO: 추후 Util 클래스 분리 고려
+    private static <T> T updateIfDifferent(T newValue, T currentValue) {
+        if (newValue == null || newValue.equals(currentValue)) {
+            return currentValue;
+        }
+        return newValue;
+    }
+}

--- a/src/main/java/com/teamflow/forestory_be/user/domain/exception/InvalidUserNameException.java
+++ b/src/main/java/com/teamflow/forestory_be/user/domain/exception/InvalidUserNameException.java
@@ -1,0 +1,17 @@
+package com.teamflow.forestory_be.user.domain.exception;
+
+import com.teamflow.forestory_be.support.common.exception.CustomException;
+
+public class InvalidUserNameException extends CustomException {
+
+    private static final String ERROR_CODE = "USER_002";
+    private static final String DEFAULT_MESSAGE = "올바르지 않은 유저 이름입니다.";
+
+    public InvalidUserNameException() {
+        super(ERROR_CODE, DEFAULT_MESSAGE);
+    }
+
+    public InvalidUserNameException(String message) {
+        super(ERROR_CODE, message);
+    }
+}

--- a/src/main/java/com/teamflow/forestory_be/user/domain/exception/UserNotFoundException.java
+++ b/src/main/java/com/teamflow/forestory_be/user/domain/exception/UserNotFoundException.java
@@ -1,0 +1,13 @@
+package com.teamflow.forestory_be.user.domain.exception;
+
+import com.teamflow.forestory_be.support.common.exception.CustomException;
+
+public class UserNotFoundException extends CustomException {
+
+    private static final String ERROR_CODE = "USER_001";
+    private static final String DEFAULT_MESSAGE = "존재하지 않는 유저입니다";
+
+    public UserNotFoundException() {
+        super(ERROR_CODE, DEFAULT_MESSAGE);
+    }
+}

--- a/src/main/java/com/teamflow/forestory_be/user/domain/repository/UserRepositoryPort.java
+++ b/src/main/java/com/teamflow/forestory_be/user/domain/repository/UserRepositoryPort.java
@@ -1,0 +1,9 @@
+package com.teamflow.forestory_be.user.domain.repository;
+
+import com.teamflow.forestory_be.user.domain.entity.User;
+
+public interface UserRepositoryPort {
+    void save(User user);
+
+    User getById(Long userId);
+}

--- a/src/main/java/com/teamflow/forestory_be/user/domain/vo/Name.java
+++ b/src/main/java/com/teamflow/forestory_be/user/domain/vo/Name.java
@@ -1,0 +1,24 @@
+package com.teamflow.forestory_be.user.domain.vo;
+
+import com.teamflow.forestory_be.user.domain.exception.InvalidUserNameException;
+import java.util.Objects;
+
+public record Name(String value) {
+
+    private static final int MIN_LENGTH = 2;
+    private static final int MAX_LENGTH = 7;
+
+    private static final String NULL_NAME = "이름을 null일 수 없습니다.";
+    private static final String EMPTY_NAME = "이름은 공백일 수 없습니다.";
+    private static final String INVALID_NAME_LENGTH = "이름은 %d자 이상 %d자 이하여야 합니다.";
+
+    public Name {
+        Objects.requireNonNull(value, NULL_NAME);
+        if (value.isEmpty()) {
+            throw new InvalidUserNameException(EMPTY_NAME);
+        }
+        if (value.length() < MIN_LENGTH || value.length() > MAX_LENGTH) {
+            throw new InvalidUserNameException(String.format(INVALID_NAME_LENGTH, MIN_LENGTH, MAX_LENGTH));
+        }
+    }
+}

--- a/src/main/java/com/teamflow/forestory_be/user/domain/vo/UserStatus.java
+++ b/src/main/java/com/teamflow/forestory_be/user/domain/vo/UserStatus.java
@@ -1,0 +1,7 @@
+package com.teamflow.forestory_be.user.domain.vo;
+
+public enum UserStatus {
+    ONBOARDING,
+    ACTIVE,
+    INACTIVE,
+}

--- a/src/main/java/com/teamflow/forestory_be/user/infrastructure/persistence/UserPersistenceAdapter.java
+++ b/src/main/java/com/teamflow/forestory_be/user/infrastructure/persistence/UserPersistenceAdapter.java
@@ -1,0 +1,29 @@
+package com.teamflow.forestory_be.user.infrastructure.persistence;
+
+import com.teamflow.forestory_be.user.domain.entity.User;
+import com.teamflow.forestory_be.user.domain.exception.UserNotFoundException;
+import com.teamflow.forestory_be.user.domain.repository.UserRepositoryPort;
+import com.teamflow.forestory_be.user.infrastructure.persistence.entity.UserJpaEntity;
+import com.teamflow.forestory_be.user.infrastructure.persistence.repository.UserJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserPersistenceAdapter implements UserRepositoryPort {
+
+    private final UserJpaRepository userJpaRepository;
+
+    @Override
+    public void save(User user) {
+        UserJpaEntity userJpaEntity = UserPersistenceMapper.toJpaEntity(user);
+        userJpaRepository.save(userJpaEntity);
+    }
+
+    @Override
+    public User getById(Long userId) {
+        return userJpaRepository.findById(userId)
+            .map(UserPersistenceMapper::toDomainEntity)
+            .orElseThrow(UserNotFoundException::new);
+    }
+}

--- a/src/main/java/com/teamflow/forestory_be/user/infrastructure/persistence/UserPersistenceMapper.java
+++ b/src/main/java/com/teamflow/forestory_be/user/infrastructure/persistence/UserPersistenceMapper.java
@@ -1,0 +1,29 @@
+package com.teamflow.forestory_be.user.infrastructure.persistence;
+
+import com.teamflow.forestory_be.user.domain.entity.User;
+import com.teamflow.forestory_be.user.domain.vo.Name;
+import com.teamflow.forestory_be.user.infrastructure.persistence.entity.UserJpaEntity;
+
+public class UserPersistenceMapper {
+
+    private UserPersistenceMapper() {
+    }
+
+    public static User toDomainEntity(UserJpaEntity userJpaEntity) {
+        return User.reconstruct(
+            userJpaEntity.getId(),
+            new Name(userJpaEntity.getName()),
+            userJpaEntity.getProfileImageUrl(),
+            userJpaEntity.getStatus()
+        );
+    }
+
+    public static UserJpaEntity toJpaEntity(User user) {
+        return UserJpaEntity.builder()
+            .id(user.getId())
+            .name(user.getName().value())
+            .profileImageUrl(user.getProfileImageUrl())
+            .status(user.getStatus())
+            .build();
+    }
+}

--- a/src/main/java/com/teamflow/forestory_be/user/infrastructure/persistence/entity/UserJpaEntity.java
+++ b/src/main/java/com/teamflow/forestory_be/user/infrastructure/persistence/entity/UserJpaEntity.java
@@ -1,0 +1,37 @@
+package com.teamflow.forestory_be.user.infrastructure.persistence.entity;
+
+import com.teamflow.forestory_be.support.common.domain.BaseTimeEntity;
+import com.teamflow.forestory_be.user.domain.vo.UserStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Builder
+@Table(name = "users")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserJpaEntity extends BaseTimeEntity {
+    @Id
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(name = "name", nullable = false, unique = true)
+    private String name;
+
+    @Column(name = "profile_image_url")
+    private String profileImageUrl;
+
+    @Column(name = "status", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private UserStatus status;
+}

--- a/src/main/java/com/teamflow/forestory_be/user/infrastructure/persistence/repository/UserJpaRepository.java
+++ b/src/main/java/com/teamflow/forestory_be/user/infrastructure/persistence/repository/UserJpaRepository.java
@@ -1,0 +1,7 @@
+package com.teamflow.forestory_be.user.infrastructure.persistence.repository;
+
+import com.teamflow.forestory_be.user.infrastructure.persistence.entity.UserJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserJpaRepository extends JpaRepository<UserJpaEntity, Long> {
+}

--- a/src/test/java/com/teamflow/forestory_be/user/domain/entity/UserTest.java
+++ b/src/test/java/com/teamflow/forestory_be/user/domain/entity/UserTest.java
@@ -1,0 +1,50 @@
+package com.teamflow.forestory_be.user.domain.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.f4b6a3.tsid.TsidFactory;
+import com.teamflow.forestory_be.support.common.util.TsidGenerator;
+import com.teamflow.forestory_be.user.domain.vo.Name;
+import com.teamflow.forestory_be.user.domain.vo.UserStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class UserTest {
+
+    @BeforeEach
+    void setUp() {
+        TsidGenerator.initialize(TsidFactory.newInstance256(0));
+    }
+
+    @Test
+    @DisplayName("유저를 정상적으로 생성한다.")
+    void should_create_user() {
+        // given
+        Name name = new Name("name");
+        String profileImageUrl = "https://image.com/test.png";
+
+        // when
+        User user = User.create(name, profileImageUrl);
+
+        // then
+        assertThat(user.getId()).isNotNull();
+        assertThat(user.getName()).isEqualTo(new Name("name"));
+        assertThat(user.getStatus()).isEqualTo(UserStatus.ONBOARDING);
+    }
+
+    @Test
+    @DisplayName("유저 이름을 정상적으로 수정한다.")
+    void should_update_user_name() {
+        // given
+        User user = User.create(new Name("name"), "https://image.com/test.png");
+
+        // when
+        User updatedUser = user.update(new Name("newname"), "https://image.com/test.png");
+
+        // then
+        assertThat(user.getId()).isEqualTo(updatedUser.getId());
+        assertThat(updatedUser.getName()).isEqualTo(new Name("newname"));
+        assertThat(updatedUser.getProfileImageUrl()).isEqualTo("https://image.com/test.png");
+    }
+}

--- a/src/test/java/com/teamflow/forestory_be/user/domain/vo/NameTest.java
+++ b/src/test/java/com/teamflow/forestory_be/user/domain/vo/NameTest.java
@@ -27,7 +27,7 @@ class NameTest {
 
         @Test
         @DisplayName("이름이 최소/최대 길이일 때 생성된다.")
-        void should_crate_name_when_length_is_min_or_max() {
+        void should_create_name_when_length_is_min_or_max() {
             // given & when & then
             assertThatCode(() -> new Name("ab"))
                 .doesNotThrowAnyException();
@@ -59,6 +59,7 @@ class NameTest {
         @Test
         @DisplayName("이름이 2자 미만이면 예외가 발생해야 한다.")
         void should_throw_when_too_short() {
+            // given & when & then
             assertThatThrownBy(() -> new Name("a"))
                 .isInstanceOf(InvalidUserNameException.class);
         }
@@ -66,6 +67,7 @@ class NameTest {
         @Test
         @DisplayName("이름이 7자 초과이면 예외가 발생해야 한다.")
         void should_throw_when_too_long() {
+            // given & when & then
             assertThatThrownBy(() -> new Name("abcdefgh"))
                 .isInstanceOf(InvalidUserNameException.class);
         }

--- a/src/test/java/com/teamflow/forestory_be/user/domain/vo/NameTest.java
+++ b/src/test/java/com/teamflow/forestory_be/user/domain/vo/NameTest.java
@@ -1,0 +1,73 @@
+package com.teamflow.forestory_be.user.domain.vo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.teamflow.forestory_be.user.domain.exception.InvalidUserNameException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class NameTest {
+
+    @Nested
+    @DisplayName("정상 케이스")
+    class ValidNameTest {
+
+        @Test
+        @DisplayName("정상적인 이름을 생성한다.")
+        void should_create_valid_name() {
+            //  given & when
+            Name name = new Name("test");
+
+            // then
+            assertThat(name).isEqualTo(new Name("test"));
+        }
+
+        @Test
+        @DisplayName("이름이 최소/최대 길이일 때 생성된다.")
+        void should_crate_name_when_length_is_min_or_max() {
+            // given & when & then
+            assertThatCode(() -> new Name("ab"))
+                .doesNotThrowAnyException();
+            assertThatCode(() -> new Name("abcdefg"))
+                .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 케이스")
+    class InvalidNameTest {
+
+        @Test
+        @DisplayName("이름이 null이면 예외가 발생한다.")
+        void should_throw_when_null() {
+            // given & when & then
+            assertThatThrownBy(() -> new Name(null))
+                .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        @DisplayName("이름이 빈 문자열이면 예외가 발생한다.")
+        void should_throw_when_empty() {
+            // given & when & then
+            assertThatThrownBy(() -> new Name(""))
+                .isInstanceOf(InvalidUserNameException.class);
+        }
+
+        @Test
+        @DisplayName("이름이 2자 미만이면 예외가 발생해야 한다.")
+        void should_throw_when_too_short() {
+            assertThatThrownBy(() -> new Name("a"))
+                .isInstanceOf(InvalidUserNameException.class);
+        }
+
+        @Test
+        @DisplayName("이름이 7자 초과이면 예외가 발생해야 한다.")
+        void should_throw_when_too_long() {
+            assertThatThrownBy(() -> new Name("abcdefgh"))
+                .isInstanceOf(InvalidUserNameException.class);
+        }
+    }
+}


### PR DESCRIPTION
## 📝 개요

- `User` 기능을 위한 패키지 구조 설정 및 기본 CRU 기능을 추가합니다.

## 🔥 변경 사항

- `User` 관련 `application`, `domain`, `infrastructure` 레이어 추가
- 기본적인 생성, 수정, 조회 메서드 추가
- `application` 레이어의 `dto` 추가
    - 리소스의 변경이 있다면 `Command`, 변경 없이 조회라면 `Query`임을 명시했습니다.
    - 추후 `presentation` 레이어에서 API 요청을 받는 `Request`, `Response` 와는 다른 dto 입니다.
- 도메인 클래스 단위 테스트 코드 추가
    
## 🔗 관련 이슈

- closed #8 

## 🧪 테스트 방법

- `User` 도메인 클래스 테스트 코드 추가
- `Name` vo 클래스 테스트 코드 추가

## ℹ️ 참고 사항
 
- 해당 구조가 확정은 아니고 추후 논의를 통해 변경될 수 있습니다!
- `User`와 `Auth` 를 분리하여 개발할 계획입니다. (관심사 분리)
- 삭제 기능은 아직 추가하지 않았습니다. 추후 `hard delete`, `soft delete` 등 삭제 정책을 얘기해보면 좋을 것 같습니다.