### PR TITLE
feat: 전역 예외 처리 기능 추가

### DIFF
--- a/src/main/java/com/teamflow/forestory_be/support/common/advice/BaseErrorCode.java
+++ b/src/main/java/com/teamflow/forestory_be/support/common/advice/BaseErrorCode.java
@@ -1,0 +1,21 @@
+package com.teamflow.forestory_be.support.common.advice;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum BaseErrorCode {
+    INVALID_REQUEST_ERROR("잘못된 요청입니다.", HttpStatus.BAD_REQUEST),
+    AUTHENTICATION_ERROR("잘못된 인증 정보입니다.", HttpStatus.UNAUTHORIZED),
+    ACCESS_DENIED_ERROR("잘못된 접근 권한입니다.", HttpStatus.FORBIDDEN),
+    UNKNOWN_ERROR("알 수 없는 에러가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    ;
+
+    private final String message;
+    private final HttpStatus status;
+
+    BaseErrorCode(String message, HttpStatus status) {
+        this.message = message;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/teamflow/forestory_be/support/common/advice/BaseErrorResponse.java
+++ b/src/main/java/com/teamflow/forestory_be/support/common/advice/BaseErrorResponse.java
@@ -1,0 +1,7 @@
+package com.teamflow.forestory_be.support.common.advice;
+
+public record BaseErrorResponse(
+    String code,
+    String message
+) {
+}

--- a/src/main/java/com/teamflow/forestory_be/support/common/advice/GlobalExceptionAdvice.java
+++ b/src/main/java/com/teamflow/forestory_be/support/common/advice/GlobalExceptionAdvice.java
@@ -1,0 +1,81 @@
+package com.teamflow.forestory_be.support.common.advice;
+
+import com.teamflow.forestory_be.auth.domain.exception.AlreadyExpiredTokenException;
+import com.teamflow.forestory_be.auth.domain.exception.InvalidTokenException;
+import com.teamflow.forestory_be.auth.domain.exception.NotSupportSocialTypeException;
+import com.teamflow.forestory_be.auth.domain.exception.UnMatchUserException;
+import com.teamflow.forestory_be.support.common.exception.CustomException;
+import java.nio.file.AccessDeniedException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestCookieException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionAdvice {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<BaseErrorResponse> handleCustomException(CustomException ex) {
+        log.warn(ex.getLocalizedMessage());
+
+        BaseErrorResponse body = new BaseErrorResponse(ex.getCode(), ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+    }
+
+    @ExceptionHandler({
+        AlreadyExpiredTokenException.class,
+        InvalidTokenException.class,
+        NotSupportSocialTypeException.class,
+        UnMatchUserException.class
+    })
+    public ResponseEntity<BaseErrorResponse> handleAuthenticationException(Exception ex) {
+        log.warn(ex.getLocalizedMessage());
+
+        BaseErrorCode errorCode = BaseErrorCode.AUTHENTICATION_ERROR;
+        BaseErrorResponse body = new BaseErrorResponse(errorCode.name(), errorCode.getMessage());
+        return ResponseEntity.status(errorCode.getStatus()).body(body);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<BaseErrorResponse> handleAccessDeniedException(AccessDeniedException ex) {
+        log.warn(ex.getLocalizedMessage());
+
+        BaseErrorCode errorCode = BaseErrorCode.ACCESS_DENIED_ERROR;
+        BaseErrorResponse body = new BaseErrorResponse(errorCode.name(), errorCode.getMessage());
+        return ResponseEntity.status(errorCode.getStatus()).body(body);
+    }
+
+    @ExceptionHandler({
+        IllegalArgumentException.class,
+        NoResourceFoundException.class,
+        MissingRequestCookieException.class,
+        MethodArgumentNotValidException.class,
+        HttpMessageNotReadableException.class,
+        MethodArgumentTypeMismatchException.class,
+        HttpRequestMethodNotSupportedException.class
+    })
+    public ResponseEntity<BaseErrorResponse> handleInvalidRequestException(Exception e) {
+        log.warn(e.getLocalizedMessage());
+
+        BaseErrorCode errorCode = BaseErrorCode.INVALID_REQUEST_ERROR;
+        BaseErrorResponse body = new BaseErrorResponse(errorCode.name(), errorCode.getMessage());
+        return ResponseEntity.status(errorCode.getStatus()).body(body);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<BaseErrorResponse> handleUnCatchException(Exception e) {
+        log.error("Uncaught exception: {}", e.getClass(), e);
+
+        BaseErrorCode errorCode = BaseErrorCode.UNKNOWN_ERROR;
+        BaseErrorResponse body = new BaseErrorResponse(errorCode.name(), errorCode.getMessage());
+        return ResponseEntity.status(errorCode.getStatus()).body(body);
+    }
+}


### PR DESCRIPTION
## 📝 개요

- 전역 예외 처리 기능을 추가합니다.

## 🔥 변경 사항

- `BaseErrorCode`, `BaseErrorResponse` 추가
- `GlobalExceptionAdvice` 추가 


## 🔗 관련 이슈

- closed #17 

## 🧪 테스트 방법

- Postman 

## ℹ️ 참고 사항

- 전역 예외 처리 및 응답 기능을 추가했습니다. 아래 사진처럼 공통 형식으로 에러 응답을 반환합니다.
<img width="500" alt="image" src="https://github.com/user-attachments/assets/6127a544-0306-4ce0-baaa-fb2127f04a63" />
