### PR TITLE
feat: 공통 응답 처리 기능 추가

### DIFF
--- a/src/main/java/com/teamflow/forestory_be/support/common/advice/BaseApiResponse.java
+++ b/src/main/java/com/teamflow/forestory_be/support/common/advice/BaseApiResponse.java
@@ -1,0 +1,17 @@
+package com.teamflow.forestory_be.support.common.advice;
+
+import java.time.Instant;
+
+public record BaseApiResponse(
+    String path,
+    Object results,
+    Long timestamp
+) {
+    public BaseApiResponse(String path, Object results) {
+        this(path, results, Instant.now().getEpochSecond());
+    }
+
+    public BaseApiResponse(String path) {
+        this(path, null, Instant.now().getEpochSecond());
+    }
+}

--- a/src/main/java/com/teamflow/forestory_be/support/common/advice/GlobalApiResponseAdvice.java
+++ b/src/main/java/com/teamflow/forestory_be/support/common/advice/GlobalApiResponseAdvice.java
@@ -1,0 +1,51 @@
+package com.teamflow.forestory_be.support.common.advice;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class GlobalApiResponseAdvice implements ResponseBodyAdvice {
+
+    private static final String API_PREFIX = "/api/";
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class converterType) {
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(
+        Object body,
+        MethodParameter returnType,
+        MediaType selectedContentType,
+        Class selectedConverterType,
+        ServerHttpRequest request,
+        ServerHttpResponse response
+    ) {
+        String path = request.getURI().getPath();
+
+        if (!path.startsWith(API_PREFIX)) {
+            return body;
+        }
+
+        if (body instanceof String) {
+            response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+            try {
+                return objectMapper.writeValueAsString(new BaseApiResponse(path, body));
+            } catch (Exception ex) {
+                throw new RuntimeException("Failed to serialize String response", ex);
+            }
+        }
+
+        return new BaseApiResponse(path, body);
+    }
+}


### PR DESCRIPTION
## 📝 개요

- API 공통 응답 처리 기능을 추가합니다.

## 🔥 변경 사항

- `BaseApiResponse` 추가
- `GlobalApiAdvice` 추가


## 🔗 관련 이슈

- closed #21 

## 🧪 테스트 방법

- Postman

## ℹ️ 참고 사항
 
- API 응답 형식을 통일합니다. 데이터 반환시 기존대로 컨트롤러에서 특별한 설정 없이 `ResponseEntity`로 반환해주시면 됩니다. 아래는 응답 예시입니다.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/425f995f-3a4a-46e5-8f2a-bd5c21cb4ff4" />

