### PR TITLE
feat: 이메일 회원가입 및 로그인 기능 추가

### DIFF
--- a/src/main/java/com/teamflow/forestory_be/auth/application/AuthService.java
+++ b/src/main/java/com/teamflow/forestory_be/auth/application/AuthService.java
@@ -1,6 +1,7 @@
 package com.teamflow.forestory_be.auth.application;
 
 import com.teamflow.forestory_be.auth.application.dto.DeleteTokenCommand;
+import com.teamflow.forestory_be.auth.application.dto.FirebaseLoginCommand;
 import com.teamflow.forestory_be.auth.application.dto.IssueTokenCommand;
 import com.teamflow.forestory_be.auth.application.dto.ReissueTokenCommand;
 import com.teamflow.forestory_be.auth.application.dto.SocialLoginCommand;
@@ -32,6 +33,13 @@ public class AuthService {
             .orElseGet(() -> createNewUser(command));
     }
 
+    @Transactional
+    public Long firebaseLogin(FirebaseLoginCommand command) {
+        return authUserRepositoryPort.getByFirebaseUid(command.firebaseUid())
+            .map(AuthUser::getUserId)
+            .orElseGet(() -> createNewFirebaseUser(command));
+    }
+
     public Long issueToken(IssueTokenCommand command) {
         Token token = Token.create(command.userId());
         return tokenRepositoryPort.save(token).getId();
@@ -51,6 +59,14 @@ public class AuthService {
         String name = RandomNameGenerator.generate().value();
         Long userId = userService.create(new CreateUserCommand(name, null));
         AuthUser authUser = AuthUser.createSocial(userId, command.socialId(), command.socialType());
+        authUserRepositoryPort.save(authUser);
+        return userId;
+    }
+
+    private Long createNewFirebaseUser(FirebaseLoginCommand command) {
+        String name = RandomNameGenerator.generate().value();
+        Long userId = userService.create(new CreateUserCommand(name, command.email()));
+        AuthUser authUser = AuthUser.createEmail(userId, command.email(), command.firebaseUid());
         authUserRepositoryPort.save(authUser);
         return userId;
     }

--- a/src/main/java/com/teamflow/forestory_be/auth/application/FirebaseService.java
+++ b/src/main/java/com/teamflow/forestory_be/auth/application/FirebaseService.java
@@ -1,0 +1,36 @@
+package com.teamflow.forestory_be.auth.application;
+
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseAuthException;
+import com.google.firebase.auth.FirebaseToken;
+import com.teamflow.forestory_be.auth.application.dto.FirebaseLoginCommand;
+import com.teamflow.forestory_be.auth.domain.exception.EmailNotVerifiedException;
+import com.teamflow.forestory_be.auth.domain.exception.InvalidTokenException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+// TODO: 인프라 레이어로 분리
+@Service
+@RequiredArgsConstructor
+public class FirebaseService {
+
+    private final FirebaseApp firebaseApp;
+
+    public FirebaseLoginCommand verify(String idToken) {
+        try {
+            FirebaseToken firebaseToken = FirebaseAuth.getInstance(firebaseApp).verifyIdToken(idToken);
+
+            if (!firebaseToken.isEmailVerified()) {
+                throw new EmailNotVerifiedException();
+            }
+
+            return new FirebaseLoginCommand(
+                firebaseToken.getEmail(),
+                firebaseToken.getUid()
+            );
+        } catch (FirebaseAuthException ex) {
+            throw new InvalidTokenException();
+        }
+    }
+}

--- a/src/main/java/com/teamflow/forestory_be/auth/application/dto/FirebaseLoginCommand.java
+++ b/src/main/java/com/teamflow/forestory_be/auth/application/dto/FirebaseLoginCommand.java
@@ -1,0 +1,7 @@
+package com.teamflow.forestory_be.auth.application.dto;
+
+public record FirebaseLoginCommand(
+    String email,
+    String firebaseUid
+) {
+}

--- a/src/main/java/com/teamflow/forestory_be/auth/domain/entity/AuthUser.java
+++ b/src/main/java/com/teamflow/forestory_be/auth/domain/entity/AuthUser.java
@@ -28,9 +28,9 @@ public class AuthUser {
         return new AuthUser(id, userId, socialAuth);
     }
 
-    public static AuthUser createEmail(Long userId, String email, String password, String firebaseUid) {
+    public static AuthUser createEmail(Long userId, String email, String firebaseUid) {
         Long id = TsidGenerator.generate();
-        EmailAuth emailAuth = new EmailAuth(email, password, firebaseUid);
+        EmailAuth emailAuth = new EmailAuth(email, firebaseUid);
         return new AuthUser(id, userId, emailAuth);
     }
 }

--- a/src/main/java/com/teamflow/forestory_be/auth/domain/exception/EmailNotVerifiedException.java
+++ b/src/main/java/com/teamflow/forestory_be/auth/domain/exception/EmailNotVerifiedException.java
@@ -1,0 +1,13 @@
+package com.teamflow.forestory_be.auth.domain.exception;
+
+import com.teamflow.forestory_be.support.common.exception.CustomException;
+
+public class EmailNotVerifiedException extends CustomException {
+
+    private static final String ERROR_CODE = "AUTH_005";
+    private static final String DEFAULT_MESSAGE = "검증되지 않은 이메일입니다";
+
+    public EmailNotVerifiedException() {
+        super(ERROR_CODE, DEFAULT_MESSAGE);
+    }
+}

--- a/src/main/java/com/teamflow/forestory_be/auth/domain/repository/AuthUserRepositoryPort.java
+++ b/src/main/java/com/teamflow/forestory_be/auth/domain/repository/AuthUserRepositoryPort.java
@@ -10,7 +10,7 @@ public interface AuthUserRepositoryPort {
 
     AuthUser getByEmail(String email);
 
-    AuthUser getByFirebaseUid(String token);
+    Optional<AuthUser> getByFirebaseUid(String uid);
 
     Optional<AuthUser> getBySocialIdAndType(String socialId, SocialType socialType);
 }

--- a/src/main/java/com/teamflow/forestory_be/auth/domain/vo/EmailAuth.java
+++ b/src/main/java/com/teamflow/forestory_be/auth/domain/vo/EmailAuth.java
@@ -4,13 +4,11 @@ import java.util.Objects;
 
 public record EmailAuth(
     String email,
-    String password,
     String firebaseUid
 ) implements AuthMethod {
 
     public EmailAuth {
         Objects.requireNonNull(email, "email must not be null");
-        Objects.requireNonNull(password, "password must not be null");
     }
 
     public SocialType socialType() {

--- a/src/main/java/com/teamflow/forestory_be/auth/infrastructure/persistence/AuthUserPersistenceAdapter.java
+++ b/src/main/java/com/teamflow/forestory_be/auth/infrastructure/persistence/AuthUserPersistenceAdapter.java
@@ -30,10 +30,9 @@ public class AuthUserPersistenceAdapter implements AuthUserRepositoryPort {
     }
 
     @Override
-    public AuthUser getByFirebaseUid(String token) {
-        return authUserJpaRepository.findByFirebaseUid(token)
-            .map(AuthUserPersistenceMapper::toDomainEntity)
-            .orElseThrow(EntityNotFoundException::new);
+    public Optional<AuthUser> getByFirebaseUid(String uid) {
+        return authUserJpaRepository.findByFirebaseUid(uid)
+            .map(AuthUserPersistenceMapper::toDomainEntity);
     }
 
     @Override

--- a/src/main/java/com/teamflow/forestory_be/auth/infrastructure/persistence/AuthUserPersistenceMapper.java
+++ b/src/main/java/com/teamflow/forestory_be/auth/infrastructure/persistence/AuthUserPersistenceMapper.java
@@ -17,7 +17,6 @@ public final class AuthUserPersistenceMapper {
             return AuthUser.createEmail(
                 authUserJpaEntity.getUserId(),
                 authUserJpaEntity.getEmail(),
-                authUserJpaEntity.getPassword(),
                 authUserJpaEntity.getFirebaseUid()
             );
         }
@@ -35,7 +34,6 @@ public final class AuthUserPersistenceMapper {
                 .id(authUser.getId())
                 .userId(authUser.getUserId())
                 .email(emailAuth.email())
-                .password(emailAuth.password())
                 .firebaseUid(emailAuth.firebaseUid())
                 .build();
         }

--- a/src/main/java/com/teamflow/forestory_be/auth/infrastructure/persistence/AuthUserPersistenceMapper.java
+++ b/src/main/java/com/teamflow/forestory_be/auth/infrastructure/persistence/AuthUserPersistenceMapper.java
@@ -35,6 +35,7 @@ public final class AuthUserPersistenceMapper {
                 .userId(authUser.getUserId())
                 .email(emailAuth.email())
                 .firebaseUid(emailAuth.firebaseUid())
+                .socialType(emailAuth.socialType())
                 .build();
         }
         SocialAuth socialAuth = (SocialAuth) authMethod;

--- a/src/main/java/com/teamflow/forestory_be/auth/infrastructure/persistence/entity/AuthUserJpaEntity.java
+++ b/src/main/java/com/teamflow/forestory_be/auth/infrastructure/persistence/entity/AuthUserJpaEntity.java
@@ -32,9 +32,6 @@ public class AuthUserJpaEntity extends BaseTimeEntity {
     @Column(name = "email", unique = true)
     private String email;
 
-    @Column(name = "password")
-    private String password;
-
     @Column(name = "firebase_uid")
     private String firebaseUid;
 

--- a/src/main/java/com/teamflow/forestory_be/auth/infrastructure/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/teamflow/forestory_be/auth/infrastructure/security/JwtAuthenticationFilter.java
@@ -7,6 +7,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -19,12 +20,20 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private static final String BEARER_PREFIX = "Bearer ";
+    private static final List<String> NO_AUTH_PATHS = List.of("/api/v1/auth/firebase/login");
 
     private final JwtExtractor jwtExtractor;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
         throws ServletException, IOException {
+        String path = request.getRequestURI();
+
+        if (NO_AUTH_PATHS.contains(path)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         String accessToken = extractAccessToken(request);
 
         if (accessToken != null) {

--- a/src/main/java/com/teamflow/forestory_be/auth/infrastructure/security/SecurityIgnorePath.java
+++ b/src/main/java/com/teamflow/forestory_be/auth/infrastructure/security/SecurityIgnorePath.java
@@ -28,6 +28,7 @@ public final class SecurityIgnorePath {
 
             // Auth
             new AntPathRequestMatcher("/api/v1/auth/reissue", HttpMethod.POST.name()),
+            new AntPathRequestMatcher("/api/v1/auth/firebase/login", HttpMethod.POST.name()),
 
             // Article
             new AntPathRequestMatcher("/api/v1/articles/**")

--- a/src/main/java/com/teamflow/forestory_be/auth/presentation/AuthController.java
+++ b/src/main/java/com/teamflow/forestory_be/auth/presentation/AuthController.java
@@ -1,7 +1,10 @@
 package com.teamflow.forestory_be.auth.presentation;
 
 import com.teamflow.forestory_be.auth.application.AuthService;
+import com.teamflow.forestory_be.auth.application.FirebaseService;
 import com.teamflow.forestory_be.auth.application.dto.DeleteTokenCommand;
+import com.teamflow.forestory_be.auth.application.dto.FirebaseLoginCommand;
+import com.teamflow.forestory_be.auth.application.dto.IssueTokenCommand;
 import com.teamflow.forestory_be.auth.application.dto.ReissueTokenCommand;
 import com.teamflow.forestory_be.auth.infrastructure.jwt.JwtExtractor;
 import com.teamflow.forestory_be.auth.infrastructure.jwt.JwtProvider;
@@ -17,6 +20,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -31,6 +35,7 @@ public class AuthController {
     private static final String REFRESH_TOKEN = "refresh_token";
 
     private final AuthService authService;
+    private final FirebaseService firebaseService;
     private final CookieHandler cookieHandler;
     private final JwtExtractor jwtExtractor;
     private final JwtProvider jwtProvider;
@@ -62,6 +67,19 @@ public class AuthController {
         response.addHeader(HttpHeaders.SET_COOKIE, expiredCookie.toString());
 
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/firebase/login")
+    public ResponseEntity<TokenResponse> firebaseLogin(
+        @RequestHeader("Authorization") String idToken,
+        HttpServletResponse response
+    ) {
+        String token = idToken.substring(7);
+        FirebaseLoginCommand command = firebaseService.verify(token);
+
+        Long userId = authService.firebaseLogin(command);
+        Long tokenId = authService.issueToken(new IssueTokenCommand(userId));
+        return createTokenResponse(userId, tokenId, response);
     }
 
     private ResponseEntity<TokenResponse> createTokenResponse(Long userId, Long tokenId, HttpServletResponse response) {


### PR DESCRIPTION
## 📝 개요

- Firebase 기반 이메일 회원가입 및 로그인 기능 추가

## 🔥 변경 사항

- Firebase 회원가입 및 로그인 API 추가
- Firebase 로그인 이후 JWT 토큰 발급 로직 추가

## 🔗 관련 이슈

- closed #13

## 🧪 테스트 방법

- Postman 을 통한 회원가입 및 로그인 API 테스트 완료
- 프론트엔드 연결하여 Firebase idToken 을 통한 검증 완료 

## ℹ️ 참고 사항
 
- 기존 구현 방향은 서버에서 사용자의 이메일, 비밀번호를 모두 가지고 있도록 하려고 했지만, 보안상 유저 데이터는 `Firebase` 에 위임하고, 클라이언트에서 uid를 전달하면 이를 서버에서 검증 -> 서버의 JWT 토큰 전달 방식으로 구현했습니다.
- 소셜 로그인, Firebase 인증 모두 외부 서비스에 의존하고 있기 때문에 장애 발생시 저희 서버에도 영향을 미칩니다. 따라서 추후 해당 문제를 보완해야할 것 같습니다.