### PR TITLE
fix: RedisTemplate 빈 메서드에 @Primary 추가

### DIFF
--- a/src/main/java/com/teamflow/forestory_be/support/config/RedisConfig.java
+++ b/src/main/java/com/teamflow/forestory_be/support/config/RedisConfig.java
@@ -3,6 +3,7 @@ package com.teamflow.forestory_be.support.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -23,6 +24,7 @@ public class RedisConfig {
     }
 
     @Bean
+    @Primary
     public RedisTemplate<String, String> redisTemplate() {
         RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());


### PR DESCRIPTION
## 📝 개요

 <!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->
- `RedisTemplate` 빈 주입시 발생한 예외를 해결합니다.

## 🔥 변경 사항

 <!-- 코드나 기능의 주요 변경 사항을 설명 -->
- `RedisTemplate` 빈 메서드에 `@Primary` 어노테이션 추가

## 🔗 관련 이슈

 <!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략) -->

- closed #45