### PR TITLE
refactor: 테스트를 위한 Firebase 이메일 인증 조건 변경

### DIFF
--- a/src/main/java/com/teamflow/forestory_be/auth/application/FirebaseService.java
+++ b/src/main/java/com/teamflow/forestory_be/auth/application/FirebaseService.java
@@ -5,12 +5,11 @@ import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseAuthException;
 import com.google.firebase.auth.FirebaseToken;
 import com.teamflow.forestory_be.auth.application.dto.FirebaseLoginCommand;
-import com.teamflow.forestory_be.auth.domain.exception.EmailNotVerifiedException;
 import com.teamflow.forestory_be.auth.domain.exception.InvalidTokenException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-// TODO: 인프라 레이어로 분리
+// TODO: 인프라 레이어로 분리, 테스트 후 이메일 검증 로직 추가
 @Service
 @RequiredArgsConstructor
 public class FirebaseService {
@@ -21,9 +20,9 @@ public class FirebaseService {
         try {
             FirebaseToken firebaseToken = FirebaseAuth.getInstance(firebaseApp).verifyIdToken(idToken);
 
-            if (!firebaseToken.isEmailVerified()) {
-                throw new EmailNotVerifiedException();
-            }
+//            if (!firebaseToken.isEmailVerified()) {
+//                throw new EmailNotVerifiedException();
+//            }
 
             return new FirebaseLoginCommand(
                 firebaseToken.getEmail(),


### PR DESCRIPTION
## 📝 개요

- Firebase 로그인 기능 테스트를 위해 이메일 검증 조건을 변경합니다.

## 🔥 변경 사항

 <!-- 코드나 기능의 주요 변경 사항을 설명 -->
- `FirebaseToken` 이메일 검증 로직 비활성화 


## 🔗 관련 이슈

- closed #50

## ℹ️ 참고 사항
 
-  프론트엔드 개발자분과 상의한 뒤 개발 서버에서만 테스트할 수 있도록 잠시 검증 로직을 주석 처리 하였습니다. 추후 다시 적용할 예정입니다.