### PR TITLE
fix: Swagger 요청 바디 snake case 적용 설정 추가

### DIFF
--- a/src/main/java/com/teamflow/forestory_be/support/config/SwaggerModelResolverConfig.java
+++ b/src/main/java/com/teamflow/forestory_be/support/config/SwaggerModelResolverConfig.java
@@ -1,0 +1,16 @@
+package com.teamflow.forestory_be.support.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import io.swagger.v3.core.jackson.ModelResolver;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerModelResolverConfig {
+
+    @Bean
+    public ModelResolver modelResolver(ObjectMapper objectMapper) {
+        return new ModelResolver(objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE));
+    }
+}


### PR DESCRIPTION
## 📝 개요

- Swagger 테스트시 요청 바디에 `snake case` 적용이 안되어 null 로 전달되는 문제 해결

## 🔥 변경 사항

 <!-- 코드나 기능의 주요 변경 사항을 설명 -->
- `SwaggerModelResolverConfig` 추가

## 🔗 관련 이슈

 <!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략) -->

- closed #56

## 🧪 테스트 방법

 <!-- 어떤 방식으로 테스트 했는지 설명 -->
- Swagger

## ℹ️ 참고 사항

- 기존 Swagger 테스트시 Request Body는 아래와 같았습니다.
```json
{
  "name": "string",
  "profileUrl": "string"
}
```

서버에선 HTTP 요청시 직렬화/역직렬화 설정을 해놨지만, 계속 `null` 값으로 들어가 확인해보니 Swagger 에서 기본 설정이 적용되어 `camel case`로 요청을 보내어 발생한 문제였습니다. 따라서 설정을 추가해 수동으로 바꾸지 않아도 아래 처럼 요청을 보낼 수 있습니다.

```json
{
  "name": "string",
  "profile_url": "string"
}
```