### PR TITLE
feat: 유저 연락 링크 필드 추가 및 VO 변환

### DIFF
--- a/src/main/java/com/teamflow/forestory_be/article/presentation/dto/response/ArticleAuthorResponse.java
+++ b/src/main/java/com/teamflow/forestory_be/article/presentation/dto/response/ArticleAuthorResponse.java
@@ -3,15 +3,15 @@ package com.teamflow.forestory_be.article.presentation.dto.response;
 import com.teamflow.forestory_be.user.domain.entity.User;
 
 public record ArticleAuthorResponse(
-        Long id,
-        String name,
-        String profileImageUrl
+    Long id,
+    String name,
+    String profileImageUrl
 ) {
     public static ArticleAuthorResponse from(User author) {
         return new ArticleAuthorResponse(
-                author.getId(),
-                author.getName().value(),
-                author.getProfileImageUrl()
+            author.getId(),
+            author.getName().value(),
+            author.getProfileImageUrl().value()
         );
     }
 }

--- a/src/main/java/com/teamflow/forestory_be/story/chapter/presentation/dto/response/AuthorResponse.java
+++ b/src/main/java/com/teamflow/forestory_be/story/chapter/presentation/dto/response/AuthorResponse.java
@@ -3,17 +3,17 @@ package com.teamflow.forestory_be.story.chapter.presentation.dto.response;
 import com.teamflow.forestory_be.user.domain.entity.User;
 
 public record AuthorResponse(
-        String authorId,
-        String name,
-        String introduction,
-        String profileImageUrl
+    String authorId,
+    String name,
+    String introduction,
+    String profileImageUrl
 ) {
     public static AuthorResponse from(User user) {
         return new AuthorResponse(
-                String.valueOf(user.getId()),
-                user.getName().value(),
-                user.getIntroduction() != null ? user.getIntroduction().value() : null,
-                user.getProfileImageUrl()
+            String.valueOf(user.getId()),
+            user.getName().value(),
+            user.getIntroduction() != null ? user.getIntroduction().value() : null,
+            user.getProfileImageUrl().value()
         );
     }
 }

--- a/src/main/java/com/teamflow/forestory_be/user/application/dto/OnboardingUserCommand.java
+++ b/src/main/java/com/teamflow/forestory_be/user/application/dto/OnboardingUserCommand.java
@@ -3,7 +3,6 @@ package com.teamflow.forestory_be.user.application.dto;
 public record OnboardingUserCommand(
     Long userId,
     String name,
-    String introduction,
     String profileImageUrl
 ) {
 }

--- a/src/main/java/com/teamflow/forestory_be/user/application/dto/UpdateUserCommand.java
+++ b/src/main/java/com/teamflow/forestory_be/user/application/dto/UpdateUserCommand.java
@@ -4,6 +4,7 @@ public record UpdateUserCommand(
     Long userId,
     String name,
     String introduction,
-    String profileImageUrl
+    String profileImageUrl,
+    String contactUrl
 ) {
 }

--- a/src/main/java/com/teamflow/forestory_be/user/application/service/UserService.java
+++ b/src/main/java/com/teamflow/forestory_be/user/application/service/UserService.java
@@ -8,8 +8,10 @@ import com.teamflow.forestory_be.user.application.dto.UpdateUserCommand;
 import com.teamflow.forestory_be.user.domain.entity.User;
 import com.teamflow.forestory_be.user.domain.exception.UserNameDuplicatedException;
 import com.teamflow.forestory_be.user.domain.repository.UserRepositoryPort;
+import com.teamflow.forestory_be.user.domain.vo.ContactUrl;
 import com.teamflow.forestory_be.user.domain.vo.Introduction;
 import com.teamflow.forestory_be.user.domain.vo.Name;
+import com.teamflow.forestory_be.user.domain.vo.ProfileImageUrl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,9 +25,10 @@ public class UserService {
     @Transactional
     public Long create(CreateUserCommand command) {
         Name name = new Name(command.name());
+        ProfileImageUrl profileImageUrl = new ProfileImageUrl(command.profileImageUrl());
         User user = User.create(
             name,
-            command.profileImageUrl()
+            profileImageUrl
         );
         return userRepositoryPort.save(user);
     }
@@ -34,10 +37,11 @@ public class UserService {
     public User completeOnboarding(OnboardingUserCommand command) {
         User user = userRepositoryPort.getById(command.userId());
         Name name = new Name(command.name());
-        validateNameDuplicated(name);
-        Introduction introduction = new Introduction(command.introduction());
+        ProfileImageUrl profileImageUrl = new ProfileImageUrl(command.profileImageUrl());
 
-        User updatedUser = user.completeOnboarding(command.userId(), name, introduction,command.profileImageUrl());
+        validateNameDuplicated(name);
+
+        User updatedUser = user.completeOnboarding(command.userId(), name, profileImageUrl);
         userRepositoryPort.save(updatedUser);
         return updatedUser;
     }
@@ -46,12 +50,16 @@ public class UserService {
     public User update(UpdateUserCommand command) {
         User user = userRepositoryPort.getById(command.userId());
         Name name = new Name(command.name());
+        Introduction introduction = Introduction.fromNullable(command.introduction(), user.getIntroduction());
+        ProfileImageUrl profileImageUrl =
+            ProfileImageUrl.fromNullable(command.profileImageUrl(), user.getProfileImageUrl());
+        ContactUrl contactUrl = ContactUrl.fromNullable(command.contactUrl(), user.getContactUrl());
 
-        if (!name.equals(user.getName())) {
+        if (!user.isSameName(name)) {
             validateNameDuplicated(name);
         }
 
-        User updatedUser = user.update(command.userId(), name, command.profileImageUrl());
+        User updatedUser = user.update(command.userId(), name, introduction, profileImageUrl, contactUrl);
         userRepositoryPort.save(updatedUser);
         return updatedUser;
     }

--- a/src/main/java/com/teamflow/forestory_be/user/domain/entity/User.java
+++ b/src/main/java/com/teamflow/forestory_be/user/domain/entity/User.java
@@ -1,8 +1,10 @@
 package com.teamflow.forestory_be.user.domain.entity;
 
 import com.teamflow.forestory_be.support.common.util.TsidGenerator;
+import com.teamflow.forestory_be.user.domain.vo.ContactUrl;
 import com.teamflow.forestory_be.user.domain.vo.Introduction;
 import com.teamflow.forestory_be.user.domain.vo.Name;
+import com.teamflow.forestory_be.user.domain.vo.ProfileImageUrl;
 import com.teamflow.forestory_be.user.domain.vo.UserStatus;
 import java.util.Objects;
 import lombok.Getter;
@@ -12,61 +14,105 @@ public class User {
 
     private final Long id;
     private final Name name;
-    private final String profileImageUrl;
     private final UserStatus status;
     private final Introduction introduction;
+    private final ContactUrl contactUrl;
+    private final ProfileImageUrl profileImageUrl;
 
-    private User(Long id, Name name, String profileImageUrl, UserStatus status, Introduction introduction) {
+    private User(
+        Long id,
+        Name name,
+        UserStatus status,
+        ContactUrl contactUrl,
+        Introduction introduction,
+        ProfileImageUrl profileImageUrl
+    ) {
         this.id = Objects.requireNonNull(id);
         this.name = Objects.requireNonNull(name);
         this.profileImageUrl = profileImageUrl;
         this.status = Objects.requireNonNull(status);
         this.introduction = introduction; // <- 세팅(초기엔 null 가능)
+        this.contactUrl = contactUrl;
     }
 
-    public User completeOnboarding(Long userId, Name name, Introduction introduction, String profileImageUrl) {
+    public User completeOnboarding(Long userId, Name name, ProfileImageUrl profileImageUrl) {
         validateUser(userId);
         return new User(
-                this.id,
-                updateIfDifferent(name, this.name),
-                updateIfDifferent(profileImageUrl, this.profileImageUrl),
-                UserStatus.ACTIVE,
-                updateIfDifferent(introduction, this.introduction)
+            this.id,
+            updateIfDifferent(name, this.name),
+            UserStatus.ACTIVE,
+            ContactUrl.empty(),
+            Introduction.empty(),
+            updateIfDifferent(profileImageUrl, this.profileImageUrl)
         );
     }
 
-    public User update(Long userId, Name name, String profileImageUrl) {
+    public User update(
+        Long userId,
+        Name name,
+        Introduction introduction,
+        ProfileImageUrl profileImageUrl,
+        ContactUrl contactUrl
+    ) {
         validateUser(userId);
         validateStatus(UserStatus.ACTIVE);
         return new User(
-                this.id,
-                updateIfDifferent(name, this.name),
-                updateIfDifferent(profileImageUrl, this.profileImageUrl),
-                this.status,
-                this.introduction
+            this.id,
+            updateIfDifferent(name, this.name),
+            this.status,
+            updateIfDifferent(contactUrl, this.contactUrl),
+            updateIfDifferent(introduction, this.introduction),
+            updateIfDifferent(profileImageUrl, this.profileImageUrl)
         );
     }
 
-    /** 소개 변경 */
+    public boolean isSameName(Name name) {
+        return this.name.equals(name);
+    }
+
+    /**
+     * 소개 변경
+     */
     public User updateIntroduction(Long userId, Introduction introduction) {
         validateUser(userId);
         // 필요 시 상태 검증 추가: validateStatus(UserStatus.ACTIVE);
         return new User(
-                this.id,
-                this.name,
-                this.profileImageUrl,
-                this.status,
-                updateIfDifferent(introduction, this.introduction)
+            this.id,
+            this.name,
+            this.status,
+            this.contactUrl,
+            updateIfDifferent(introduction, this.introduction),
+            this.profileImageUrl
         );
     }
 
-    public static User create(Name name, String profileImageUrl) {
+    public static User create(Name name, ProfileImageUrl profileImageUrl) {
         Long id = TsidGenerator.generate();
-        return new User(id, name, profileImageUrl, UserStatus.ONBOARDING, new Introduction(""));
+        return new User(
+            id,
+            name,
+            UserStatus.ONBOARDING,
+            ContactUrl.empty(),
+            Introduction.empty(),
+            profileImageUrl
+        );
     }
 
-    public static User reconstruct(Long id, Name name, String profileImageUrl, UserStatus status, Introduction introduction) {
-        return new User(id, name, profileImageUrl, status, introduction != null ? introduction : new Introduction(""));
+    public static User reconstruct(
+        Long id, Name name,
+        ProfileImageUrl profileImageUrl,
+        UserStatus status,
+        Introduction introduction,
+        ContactUrl contactUrl
+    ) {
+        return new User(
+            id,
+            name,
+            status,
+            contactUrl,
+            introduction,
+            profileImageUrl
+        );
     }
 
     private void validateUser(Long userId) {
@@ -82,7 +128,9 @@ public class User {
     }
 
     private static <T> T updateIfDifferent(T newValue, T currentValue) {
-        if (newValue == null || newValue.equals(currentValue)) return currentValue;
+        if (newValue == null || newValue.equals(currentValue)) {
+            return currentValue;
+        }
         return newValue;
     }
 }

--- a/src/main/java/com/teamflow/forestory_be/user/domain/vo/ContactUrl.java
+++ b/src/main/java/com/teamflow/forestory_be/user/domain/vo/ContactUrl.java
@@ -1,0 +1,16 @@
+package com.teamflow.forestory_be.user.domain.vo;
+
+public record ContactUrl(
+    String value
+) {
+    public static ContactUrl empty() {
+        return new ContactUrl("");
+    }
+
+    public static ContactUrl fromNullable(String newValue, ContactUrl value) {
+        if (newValue == null || newValue.isEmpty()) {
+            return value;
+        }
+        return new ContactUrl(newValue);
+    }
+}

--- a/src/main/java/com/teamflow/forestory_be/user/domain/vo/Introduction.java
+++ b/src/main/java/com/teamflow/forestory_be/user/domain/vo/Introduction.java
@@ -1,10 +1,15 @@
 package com.teamflow.forestory_be.user.domain.vo;
 
 public record Introduction(String value) {
-    public Introduction {
-        if (value == null) {
-            value = "";
+    public static Introduction empty() {
+        return new Introduction("");
+    }
+
+    public static Introduction fromNullable(String newValue, Introduction value) {
+        if (newValue == null || newValue.isEmpty()) {
+            return value;
         }
+        return new Introduction(newValue);
     }
 }
 

--- a/src/main/java/com/teamflow/forestory_be/user/domain/vo/ProfileImageUrl.java
+++ b/src/main/java/com/teamflow/forestory_be/user/domain/vo/ProfileImageUrl.java
@@ -1,0 +1,16 @@
+package com.teamflow.forestory_be.user.domain.vo;
+
+public record ProfileImageUrl(
+    String value
+) {
+    public static ProfileImageUrl empty() {
+        return new ProfileImageUrl("");
+    }
+
+    public static ProfileImageUrl fromNullable(String newValue, ProfileImageUrl value) {
+        if (newValue == null || newValue.isEmpty()) {
+            return value;
+        }
+        return new ProfileImageUrl(newValue);
+    }
+}

--- a/src/main/java/com/teamflow/forestory_be/user/infrastructure/persistence/UserPersistenceMapper.java
+++ b/src/main/java/com/teamflow/forestory_be/user/infrastructure/persistence/UserPersistenceMapper.java
@@ -1,8 +1,10 @@
 package com.teamflow.forestory_be.user.infrastructure.persistence;
 
 import com.teamflow.forestory_be.user.domain.entity.User;
+import com.teamflow.forestory_be.user.domain.vo.ContactUrl;
 import com.teamflow.forestory_be.user.domain.vo.Introduction;
 import com.teamflow.forestory_be.user.domain.vo.Name;
+import com.teamflow.forestory_be.user.domain.vo.ProfileImageUrl;
 import com.teamflow.forestory_be.user.infrastructure.persistence.entity.UserJpaEntity;
 
 public class UserPersistenceMapper {
@@ -10,13 +12,14 @@ public class UserPersistenceMapper {
     private UserPersistenceMapper() {
     }
 
-    public static User toDomainEntity(UserJpaEntity e) {
+    public static User toDomainEntity(UserJpaEntity userJpaEntity) {
         return User.reconstruct(
-                e.getId(),
-                new Name(e.getName()),
-                e.getProfileImageUrl(),
-                e.getStatus(),
-                e.getIntroduction() != null ? new Introduction(e.getIntroduction()) : null
+            userJpaEntity.getId(),
+            new Name(userJpaEntity.getName()),
+            new ProfileImageUrl(userJpaEntity.getProfileImageUrl()),
+            userJpaEntity.getStatus(),
+            userJpaEntity.getIntroduction() != null ? new Introduction(userJpaEntity.getIntroduction()) : null,
+            new ContactUrl(userJpaEntity.getContactUrl())
         );
     }
 
@@ -25,8 +28,10 @@ public class UserPersistenceMapper {
         return UserJpaEntity.builder()
             .id(user.getId())
             .name(user.getName().value())
-            .profileImageUrl(user.getProfileImageUrl())
+            .profileImageUrl(user.getProfileImageUrl().value())
             .status(user.getStatus())
+            .introduction(user.getIntroduction().value())
+            .contactUrl(user.getContactUrl().value())
             .build();
     }
 }

--- a/src/main/java/com/teamflow/forestory_be/user/infrastructure/persistence/entity/UserJpaEntity.java
+++ b/src/main/java/com/teamflow/forestory_be/user/infrastructure/persistence/entity/UserJpaEntity.java
@@ -37,4 +37,7 @@ public class UserJpaEntity extends BaseTimeEntity {
 
     @Column(name = "introduction")
     private String introduction;
+
+    @Column(name = "contact_url")
+    private String contactUrl;
 }

--- a/src/main/java/com/teamflow/forestory_be/user/presentation/UserController.java
+++ b/src/main/java/com/teamflow/forestory_be/user/presentation/UserController.java
@@ -57,7 +57,6 @@ public class UserController implements UserApi {
         OnboardingUserCommand command = new OnboardingUserCommand(
             userId,
             request.name(),
-            request.introduction(),
             request.profileUrl()
         );
         User user = userService.completeOnboarding(command);
@@ -74,7 +73,8 @@ public class UserController implements UserApi {
             userId,
             request.name(),
             request.introduction(),
-            request.profileUrl()
+            request.profileUrl(),
+            request.contactUrl()
         );
         User user = userService.update(command);
         UserProfileResponse response = UserProfileResponse.from(user);

--- a/src/main/java/com/teamflow/forestory_be/user/presentation/dto/request/UpdateProfileRequest.java
+++ b/src/main/java/com/teamflow/forestory_be/user/presentation/dto/request/UpdateProfileRequest.java
@@ -3,6 +3,7 @@ package com.teamflow.forestory_be.user.presentation.dto.request;
 public record UpdateProfileRequest(
     String name,
     String introduction,
-    String profileUrl
+    String profileUrl,
+    String contactUrl
 ) {
 }

--- a/src/main/java/com/teamflow/forestory_be/user/presentation/dto/request/UserOnboardingRequest.java
+++ b/src/main/java/com/teamflow/forestory_be/user/presentation/dto/request/UserOnboardingRequest.java
@@ -2,7 +2,6 @@ package com.teamflow.forestory_be.user.presentation.dto.request;
 
 public record UserOnboardingRequest(
     String name,
-    String introduction,
     String profileUrl
 ) {
 }

--- a/src/main/java/com/teamflow/forestory_be/user/presentation/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/teamflow/forestory_be/user/presentation/dto/response/UserProfileResponse.java
@@ -6,7 +6,8 @@ public record UserProfileResponse(
     Long userId,
     String name,
     String introduction,
-    String profileImageUrl
+    String profileImageUrl,
+    String contactUrl
 ) {
 
     public static UserProfileResponse from(User user) {
@@ -14,7 +15,8 @@ public record UserProfileResponse(
             user.getId(),
             user.getName().value(),
             user.getIntroduction().value(),
-            user.getProfileImageUrl()
+            user.getProfileImageUrl().value(),
+            user.getContactUrl().value()
         );
     }
 }


### PR DESCRIPTION
## 📝 개요

- 유저 도메인에 `contact_url` 필드를 추가하고, 프로필 관련 기능을 수정합니다.

## 🔥 변경 사항

- 유저 도메인 `contact_url` 필드 추가
- 유저 도메인 엔티티 필드 VO화
- 프로필 변경 로직 수정

## 🔗 관련 이슈

- closed #73 

## 🧪 테스트 방법

- Postman
- Swagger