### PR TITLE
refactor: 유저 프로필 응답 프로필 이미지 주소 필드명 변경

### DIFF
--- a/src/main/java/com/teamflow/forestory_be/user/presentation/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/teamflow/forestory_be/user/presentation/dto/response/UserProfileResponse.java
@@ -6,7 +6,7 @@ public record UserProfileResponse(
     Long userId,
     String name,
     String introduction,
-    String profileImageUrl,
+    String profileUrl,
     String contactUrl
 ) {
 


### PR DESCRIPTION
## 📝 개요

 <!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->
- `UserProfileResponse` 의 프로필 이미지 주소 필드명을 `profile_url 로 변경합니다.

## 🔥 변경 사항

 <!-- 코드나 기능의 주요 변경 사항을 설명 -->
- `UserProfileResponse` 프로필 이미지 주소 필드명 변경


## 🔗 관련 이슈

 <!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략) -->

- closed #79