### PR TITLE
refactor: 유저 프로필 조회시 검증 로직 추가 및 응답 형식 변경

### DIFF
--- a/src/main/java/com/teamflow/forestory_be/user/domain/entity/User.java
+++ b/src/main/java/com/teamflow/forestory_be/user/domain/entity/User.java
@@ -94,7 +94,7 @@ public class User {
             UserStatus.ONBOARDING,
             ContactUrl.empty(),
             Introduction.empty(),
-            profileImageUrl
+            ProfileImageUrl.empty()
         );
     }
 

--- a/src/main/java/com/teamflow/forestory_be/user/domain/vo/ContactUrl.java
+++ b/src/main/java/com/teamflow/forestory_be/user/domain/vo/ContactUrl.java
@@ -8,7 +8,7 @@ public record ContactUrl(
     }
 
     public static ContactUrl fromNullable(String newValue, ContactUrl value) {
-        if (newValue == null || newValue.isEmpty()) {
+        if (newValue == null) {
             return value;
         }
         return new ContactUrl(newValue);

--- a/src/main/java/com/teamflow/forestory_be/user/domain/vo/Introduction.java
+++ b/src/main/java/com/teamflow/forestory_be/user/domain/vo/Introduction.java
@@ -6,7 +6,7 @@ public record Introduction(String value) {
     }
 
     public static Introduction fromNullable(String newValue, Introduction value) {
-        if (newValue == null || newValue.isEmpty()) {
+        if (newValue == null) {
             return value;
         }
         return new Introduction(newValue);

--- a/src/main/java/com/teamflow/forestory_be/user/domain/vo/ProfileImageUrl.java
+++ b/src/main/java/com/teamflow/forestory_be/user/domain/vo/ProfileImageUrl.java
@@ -8,7 +8,7 @@ public record ProfileImageUrl(
     }
 
     public static ProfileImageUrl fromNullable(String newValue, ProfileImageUrl value) {
-        if (newValue == null || newValue.isEmpty()) {
+        if (newValue == null) {
             return value;
         }
         return new ProfileImageUrl(newValue);

--- a/src/main/java/com/teamflow/forestory_be/user/presentation/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/teamflow/forestory_be/user/presentation/dto/response/UserProfileResponse.java
@@ -3,7 +3,7 @@ package com.teamflow.forestory_be.user.presentation.dto.response;
 import com.teamflow.forestory_be.user.domain.entity.User;
 
 public record UserProfileResponse(
-    Long userId,
+    String userId,
     String name,
     String introduction,
     String profileUrl,
@@ -12,7 +12,7 @@ public record UserProfileResponse(
 
     public static UserProfileResponse from(User user) {
         return new UserProfileResponse(
-            user.getId(),
+            user.getId().toString(),
             user.getName().value(),
             user.getIntroduction().value(),
             user.getProfileImageUrl().value(),


### PR DESCRIPTION
## 📝 개요

 <!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->
- 유저 프로필 조회시 `user_id` 가 틀린 값으로 나오는 버그 해결
- 유저 프로필 수정시 빈 값 ("") 허용하도록 변경

## 🔥 변경 사항

 <!-- 코드나 기능의 주요 변경 사항을 설명 -->
- 유저 프로필 조회시 빈 값 허용하도록 변경
- Long 타입 범위로 인한 유저 프로필 응답시 `user_id` 가 비정상적인 값으로 전달되는 버그 해결


## 🔗 관련 이슈

 <!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략) -->

- closed #85 

## 🧪 테스트 방법

 <!-- 어떤 방식으로 테스트 했는지 설명 -->
- Swagger
- Postman